### PR TITLE
Fixed typo for phrases[50]

### DIFF
--- a/bingo_host.html
+++ b/bingo_host.html
@@ -327,7 +327,7 @@ body {
     phrases[42] = "The answer to life, the universe and everything";
     phrases[43] = "Down on your knees";
     phrases[44] = "All the Fours";
-    phrases[50] = "Half a Centurty";
+    phrases[50] = "Half a Century";
     phrases[55] = "Snakes alive, All the fives";
     phrases[60] = "Blind Sixty";
     phrases[66] = "Clickety-Click";


### PR DESCRIPTION
Just a simple typo fix from 'Centurty' to 'Century'